### PR TITLE
Fix: removed the customise profile button  

### DIFF
--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -64,9 +64,6 @@ const ProfilePage = () => {
                 {user.name.charAt(0)}
               </div>
             </div>
-            <button className="mt-4 px-4 py-1 border border-gray-400 text-yellow-400 rounded-md text-sm hover:bg-yellow-400 hover:text-black transition">
-              Customise Profile
-            </button>
           </div>
           <div className="flex flex-col">
             <h1 className="text-2xl font-bold">{user.name}</h1>


### PR DESCRIPTION
### Description 

This PR removes the "Customize Profile" button from the profile page to improve UI clarity and streamline the user experience. The button was either redundant, non-functional, or no longer necessary as per the latest design decisions or user feedback.

### Related Issues
closes #47 

### Screenshot
![image](https://github.com/user-attachments/assets/8d57c4da-7482-4bbb-8816-1b7961cc7ea1)

### Additional context 
NIL